### PR TITLE
fix: use clio core for iowarp builds

### DIFF
--- a/CI/coeus/packages/coeus/package.py
+++ b/CI/coeus/packages/coeus/package.py
@@ -29,9 +29,10 @@ class Coeus(CMakePackage):
 
     maintainers("JaimeCernuda")
 
+    version('iowarp', branch='iowarp', submodules=True, preferred=True)
     version('master', branch='master', submodules=True)
 
-    depends_on("hermes@master")
+    depends_on("iowarp@main")
     depends_on("adios2")
     depends_on("sqlite")
 


### PR DESCRIPTION
## Summary

- add the maintained `iowarp` branch as the preferred Coeus Spack version
- replace the deleted `hermes@master` dependency with `iowarp@main` from `iowarp/clio-core`
- keep the legacy `master` version available explicitly

## Validation

- parsed the recipe successfully
- concretized `coeus@iowarp` against the current Clio Core Spack repository in an isolated configuration
- verified the default Coeus spec selects `coeus@iowarp ^iowarp@main`
- `git diff --check`